### PR TITLE
Changes to get "running" locally

### DIFF
--- a/run_training_template.py
+++ b/run_training_template.py
@@ -146,7 +146,7 @@ def main_worker(args):
     data_loader = {"train": train_loader, "val": val_loader}
 
     model = UNet3D(
-        in_channels=1, out_channels=1, f_maps=32
+        in_channels=params["in_channels"], out_channels=1, f_maps=32
     )
 
     # model = utils.load_weights(

--- a/run_training_template.py
+++ b/run_training_template.py
@@ -161,7 +161,7 @@ def main_worker(args):
         model, 
         weights_path="weights/best_checkpoint_exp_044.pytorch", 
         device="cpu", # Load to CPU and convert to GPU later
-        dict_key="model_state_dict"
+        dict_key="state_dict"
     )
 
     model = utils.set_parameter_requires_grad(model, trainable=True)

--- a/run_training_template.py
+++ b/run_training_template.py
@@ -208,7 +208,7 @@ def main_worker(args):
         optimizer,
         scheduler,
         num_epochs=params["epochs"],
-        neptune_run=neptune_run
+        neptune_run=None
     )
 
     # Run training/validation

--- a/run_training_template.py
+++ b/run_training_template.py
@@ -17,7 +17,7 @@ import unet.utils.data_utils as utils
 
 import neptune.new as neptune
 
-neptune_run = None
+neptune_run = {}
 
 parser = argparse.ArgumentParser(description="3DUnet Training")
 
@@ -159,7 +159,7 @@ def main_worker(args):
 
     model = utils.load_weights(
         model, 
-        weights_path="../3DUnet_lightsheet_boundary_best_checkpoint.pytorch", 
+        weights_path="weights/best_checkpoint_exp_044.pytorch", 
         device="cpu", # Load to CPU and convert to GPU later
         dict_key="model_state_dict"
     )
@@ -248,7 +248,7 @@ def main_worker(args):
         infer = Inferer(
             model=model, 
             patch_size=params["patch_size"],
-            neptune_run=neptune_run
+            neptune_run=None
             )
 
         infer.predict_from_csv(load_data)


### PR DESCRIPTION
These changes allow me to get as far as training to start on my machine. It then fails with `RuntimeError: DataLoader worker (pid 347) is killed by signal: Bus error. It is possible that dataloader's workers are out of shared memory. Please try to raise your shared memory limit.` I assume that's due to running on CPU on my Mac. 

```
docker run -it --rm ctromanscoia/unet_base:0.5

#now in docker
apt install git-lfs
pip install nd2
git lfs clone https://github.com/bethac07/UNet_3D_C_elegans.git
cd UNet_3D_C_elegans/
tar -xvzf data/images_stacked_channels/images_stacked_channels.tar.gz -C data/images_stacked_channels/
tar -xvzf data/images/images.tar.gz -C data/images/
tar -xvzf data/masks/masks.tar.gz -C data/masks/
python run_training_template.py data/data_stacked_channels_training.csv --batch 4 --epochs 1
```